### PR TITLE
Re-create users, groups and hosts with minimal information.

### DIFF
--- a/tpm-hook
+++ b/tpm-hook
@@ -17,11 +17,6 @@ esac
 copy_exec /usr/sbin/tcsd /sbin 
 copy_exec /etc/tcsd.conf /etc 
  
-# copy the host config 
-copy_exec /etc/group /etc/ 
-copy_exec /etc/passwd /etc/ 
-copy_exec /etc/hosts /etc/ 
- 
 # copy the necessary libraries 
 cp -fpL /lib/x86_64-linux-gnu/libns* ${DESTDIR}/lib/x86_64-linux-gnu/ 
  
@@ -34,3 +29,15 @@ copy_exec /usr/sbin/tpm_nvread /sbin/
 copy_exec /usr/sbin/tpm_nvinfo /sbin/
 copy_exec /sbin/getsecret.sh /sbin
 
+#create etc/passwd
+groupid=`id -G tss`
+userid=`id -u tss`
+echo "root:x:0:0:root:/root:/bin/bash" >  ${DESTDIR}/etc/passwd
+echo "tss:x:$userid:$groupid::/var/lib/tpm:/bin/false" >> ${DESTDIR}/etc/passwd
+
+#create etc/hosts
+echo "127.0.0.1 localhost\n::1     localhost ip6-localhost ip6-loopback\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n" > ${DESTDIR}/etc/hosts
+
+#create etc/group
+echo "root:x:0:" > ${DESTDIR}/etc/group
+echo "tss:x:$groupid:" >>  ${DESTDIR}/etc/group


### PR DESCRIPTION
`copy_exec` is not working with `etc/passwd` file, which address #3 

Furthermore, we do not need to copy all groups, users and hosts, it may contains data that will not be stored safely as `initrd` is not on an encrypted partition. 