### PR TITLE
Avoid loading secret after booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In case I forgot to consider something important in this decision, please let me
 
 ## Install necessary scripts
 
-We will store the secret directly in the TPM - in its NVRAM. There's a tool for that called [tpm-looks](https://github.com/shpedoikal/tpm-luks), but it seemed to be a bit top ,icj for what I needed (and only working with dracut), so I created my own bash scripts. First, to make things easier, I've created `/sbin/seal-nvram.sh`, a script that puts the content of your file in NVRAM and seals it to PCRs 0-13 if the parameter `-z` is NOT used. (I have to admit that checking for the `-z` parameter is quite hacky, but it did the job for me.) So, download seal-nvram.sh, move it to /sbin, and don't forget to make it executable:
+We will store the secret directly in the TPM - in its NVRAM. There's a tool for that called [tpm-luks](https://github.com/shpedoikal/tpm-luks), but it seemed to be a bit too much for what I needed (and only works with dracut), so I created my own bash scripts. First, to make things easier, I've created `/sbin/seal-nvram.sh`, a script that puts the content of your file in NVRAM and seals it to PCRs 0-13 if the parameter `-z` is NOT used. (I have to admit that checking for the `-z` parameter is quite hacky, but it did the job for me.) So, download seal-nvram.sh, move it to /sbin, and don't forget to make it executable:
 
 ```bash
 sudo mv seal-nvram.sh /sbin/
@@ -123,8 +123,7 @@ sudo chmod +x /sbin/seal-nvram.sh
 ```
 
 ```text
-Note: I have chosen to set the permission of the NVRAM I am creating to OWNERWRITE. Depending on 
-your situation, others might suit better. The full list of possibilities is here 
+Note: I have chosen to set the permission of the NVRAM I am creating to OWNERWRITE|READ_STCLEAR. Using READ_STCLEAR will allow us to block reading the secret from NVRAM once we decrypted our harddisk. Depending on your situation, others might suit better. The full list of possibilities is here 
 (taken from the tpm_nvdefine manpage):
 
 AUTHREAD : reading requires NVRAM area authorization
@@ -140,7 +139,7 @@ WRITEDEFINE : a write with size 0 to the same index locks the NVRAM area permane
 WRITEALL : the value must be written in a single operation
 ```
 
-Further, I have created a script that gets the content out of the NVRAM. Again, it's a bit hacky, but it does its job:
+Further, I have created a script that gets the content out of the NVRAM. This script will only be able to read the secret from NVRAM once, since it afterwards blocks further reads by reading 0 bits from the NVRAM area (see READ_STCLEAR). Again, it's a bit hacky, but it does its job:
 
 ```bash
 sudo mv getsecret.sh /sbin/

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ It works? Perfect, you are ready to go!  Enjoy having to type one password less 
 
 The system still boots up, although it shouldn't? Have a look at the next step…
 
-## Activation of PCR locking
+## Setting the nvLocked bit
 
-On one of my test systems, I had the problem that the secret stored in the NVRAM could be read even when the PCRs it was sealed to had changed. It took me quite a long time to figure out what went wrong: Apparently, the TPM manufacturer didn't set the `nvLocked` bit, which meant that reading the NVRAM was always possible, no matter if you sealed it to some PCRs or assigned a password to it. Thanks to [this discussion](https://sourceforge.net/p/trousers/mailman/message/32332373/) at the TrouSers mailing list, I was finally able to figure out what to do:
+On one of my test systems, I had the problem that the secret stored in the NVRAM could be read even when the PCRs it was sealed to had changed. It took me quite a long time to figure out what went wrong: Apparently, the TPM manufacturer didn't set the `nvLocked` bit, which means that reading the NVRAM was always possible, no matter if you sealed it to some PCRs or assigned a password to it. Thanks to [this discussion](https://sourceforge.net/p/trousers/mailman/message/32332373/) at the TrouSers mailing list, I was finally able to figure out what to do:
 
 You'll have to define an area the size 0 at position `0xFFFFFFF` in the NVRAM. This will equal setting the nvLocked bit. You can do so with the following command:
 

--- a/getsecret.sh
+++ b/getsecret.sh
@@ -5,5 +5,10 @@ INDEX=1
 # Set the size of the keyfile statically to 256
 SIZE=256
 
-#read the content of NVRAM, and cut off success-message at the end
+# read the content of NVRAM, and cut off success-message at the end
 tpm_nvread -i $INDEX -f /dev/stdout | head -c $SIZE
+
+# read the content again with size 0, to disable reading until reboot
+# For some reason, tcsd stops after the first command, so we have to start it again first and wait 1s for it to be ready
+tcsd && sleep 1
+tpm_nvread -i $INDEX -s 0 >> /dev/null

--- a/seal-nvram.sh
+++ b/seal-nvram.sh
@@ -34,5 +34,5 @@ tpm_nvdefine -i $INDEX -s $(wc -c $KEYFILE) -p $PERMISSIONS -o $OWNERPW -z $PCRS
 # Write the index if creating the index succeeded
 if [ $? -eq 0 ]
 then
-  tpm_nvwrite -i $INDEX -f $KEYFILE -p$OWNERPW -z
+  tpm_nvwrite -i $INDEX -f $KEYFILE -z -p$OWNERPW
 fi

--- a/seal-nvram.sh
+++ b/seal-nvram.sh
@@ -11,7 +11,7 @@ INDEX=1
 # The secret keyfile we will use to put into the NVRAM 
 KEYFILE="/secret.bin" 
 # The permissions we will require to read/write the NVRAM index
-PERMISSIONS="OWNERWRITE" 
+PERMISSIONS="OWNERWRITE|READ_STCLEAR" 
 
 if [ "$1" != "-z" ] 
 then 


### PR DESCRIPTION
This avoids that the secret can be read from NVRAM once the system is booted.