### PR TITLE
update getsecret.sh to use dd instead of head

### DIFF
--- a/getsecret.sh
+++ b/getsecret.sh
@@ -6,7 +6,7 @@ INDEX=1
 SIZE=256
 
 # read the content of NVRAM, and cut off success-message at the end
-tpm_nvread -i $INDEX -f /dev/stdout | head -c $SIZE
+tpm_nvread -i $INDEX -f /dev/stdout | dd if=/dev/stdin of=/dev/stdout bs=1 count=$SIZE 2>/dev/null
 
 # read the content again with size 0, to disable reading until reboot
 # For some reason, tcsd stops after the first command, so we have to start it again first and wait 1s for it to be ready


### PR DESCRIPTION
update getsecret.sh to use dd instead of head, which is not available in ubuntu 18.04 initrd

resolves #16