### PR TITLE
Support passphrase fallback

### DIFF
--- a/getsecret.sh
+++ b/getsecret.sh
@@ -2,13 +2,19 @@
 # The index in which we stored the secret. This needs to be the same as in /sbin/seal-nvram.sh
 INDEX=1 
 
-# Set the size of the keyfile statically to 256
-SIZE=256
-
-# read the content of NVRAM, and cut off success-message at the end
-tpm_nvread -i $INDEX -f /dev/stdout | dd if=/dev/stdin of=/dev/stdout bs=1 count=$SIZE 2>/dev/null
-
-# read the content again with size 0, to disable reading until reboot
-# For some reason, tcsd stops after the first command, so we have to start it again first and wait 1s for it to be ready
-tcsd && sleep 1
-tpm_nvread -i $INDEX -s 0 >> /dev/null
+# read the content of NVRAM
+if tpm_nvread -i $INDEX -f /tmp/key >/dev/null; then
+    cat /tmp/key
+    rm /tmp/key
+    # read the content again with size 0, to disable reading until reboot
+    # For some reason, tcsd stops after the first command, so we have to start it again first and wait 1s for it to be ready
+    tcsd && sleep 1
+    tpm_nvread -i $INDEX -s 0 >> /dev/null
+else
+    IN_FD="/proc/self/fd/2"
+    echo >&2 "TPM failed, please enter fallback passphrase:"
+    stty <$IN_FD -echo
+    read <$IN_FD -rs -t 10 key
+    stty <$IN_FD echo
+    echo -n $key
+fi

--- a/seal-nvram.sh
+++ b/seal-nvram.sh
@@ -25,14 +25,14 @@ read -s -p "Owner password: " OWNERPW
 tpm_nvinfo | grep \($INDEX\) > /dev/null
 if [ $? -eq 0 ]
 then
-  tpm_nvrelease -i $INDEX -o$OWNERPW
+  tpm_nvrelease -i $INDEX -o"$OWNERPW"
 fi
 
 # Create a new NVRAM index
-tpm_nvdefine -i $INDEX -s $(wc -c $KEYFILE) -p $PERMISSIONS -o $OWNERPW -z $PCRS
+tpm_nvdefine -i $INDEX -s $(wc -c $KEYFILE) -p $PERMISSIONS -o "$OWNERPW" -z $PCRS
 
 # Write the index if creating the index succeeded
 if [ $? -eq 0 ]
 then
-  tpm_nvwrite -i $INDEX -f $KEYFILE -z --password=$OWNERPW
+  tpm_nvwrite -i $INDEX -f $KEYFILE -z --password="$OWNERPW"
 fi


### PR DESCRIPTION
Additionally, use proper shell quoting so that passwords with spaces actually work.